### PR TITLE
omfwd cannot be loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ change 10.x.x.x in the below config to your GrayLog server ip.
 ~~~~
 # Load Modules
 module(load="imfile")
-module(load="omfwd")
 
 # rsyslog Input Modules
 input(type="imfile"


### PR DESCRIPTION
It is a is a rsyslog built-in module, which is always present.